### PR TITLE
Add Google Analytics tracking to layout.

### DIFF
--- a/data/templates/woocommerce/components/analytics-tracking.html.twig
+++ b/data/templates/woocommerce/components/analytics-tracking.html.twig
@@ -1,0 +1,9 @@
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-8KCYZ2CYMS"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-8KCYZ2CYMS');
+</script>

--- a/data/templates/woocommerce/layout.html.twig
+++ b/data/templates/woocommerce/layout.html.twig
@@ -18,6 +18,7 @@
     <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/@tarekraafat/autocomplete.js@7.2.0/dist/js/autoComplete.min.js"></script>
+    {% include 'components/analytics-tracking.html.twig' %}
     {% block javascripts %}
     {% endblock %}
 </head>


### PR DESCRIPTION
This PR adds a Google Analytics tracking tag to the base layout that will help us measure traffic and engagement for the pages in this resource.

I tested this out locally and it seems to be working, but I'm not sure if there is anything else I need to do to make sure it deploys to the `gh-pages` branch in this repo.  :smiley: