### PR TITLE
Add content grouping for Google Analytics.

### DIFF
--- a/data/templates/woocommerce/components/analytics-tracking.html.twig
+++ b/data/templates/woocommerce/components/analytics-tracking.html.twig
@@ -5,5 +5,7 @@
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', 'G-8KCYZ2CYMS');
+  gtag('config', 'G-8KCYZ2CYMS', {
+		'content_group' : 'WooCommerce Core Code Reference',
+	});
 </script>


### PR DESCRIPTION
This is a follow-up to #9 that adds a bit of additional configuration to our Google Analytics tracking tag so that we can segment traffic on GitHub Pages traffic more easily.