### PR TITLE
Add Woo careers page link to site header.

### DIFF
--- a/data/templates/woocommerce/components/header.html.twig
+++ b/data/templates/woocommerce/components/header.html.twig
@@ -8,6 +8,7 @@
                 <li><a href="{{ path('hooks/hooks.html') }}">Hooks Reference</a></li>
                 <li><a href="https://docs.woocommerce.com/">Documentation</a></li>
                 <li><a href="https://woocommerce.github.io/woocommerce-rest-api-docs/">REST API Docs</a></li>
+                <li><a href="https://woocommerce.com/careers/?utm_source=woocommerce+core+code+reference&utm_medium=devdocs&utm_campaign=woo+careers" target="_blank">We're hiring!</a></li>
             </ul>
         </nav>
     </section>


### PR DESCRIPTION
This PR adds an extra item to the site header with a link to the new [WooCommerce Careers](https://woocommerce.com/woocommerce) page.

Once this PR is created, I'll cross link to it from the related internal tracking issue to provide additional context here around this change.  :smiley: