### PR TITLE
Make the document title more useful

### DIFF
--- a/data/templates/woocommerce/class.html.twig
+++ b/data/templates/woocommerce/class.html.twig
@@ -1,5 +1,7 @@
 {% extends 'base.html.twig' %}
 
+{% block title %}{{ node.name }} Class | {{ project.name }}{% endblock %}
+
 {% block content %}
     {% include 'components/breadcrumbs.html.twig' %}
 

--- a/data/templates/woocommerce/file.html.twig
+++ b/data/templates/woocommerce/file.html.twig
@@ -1,5 +1,7 @@
 {% extends 'base.html.twig' %}
 
+{% block title %}{{ node.name }} | {{ project.name }}{% endblock %}
+
 {% block javascripts %}
     <script src="{{ path('js/prism.js') }}"></script>
     <script>

--- a/data/templates/woocommerce/interface.html.twig
+++ b/data/templates/woocommerce/interface.html.twig
@@ -1,5 +1,7 @@
 {% extends 'base.html.twig' %}
 
+{% block title %}{{ node.name }} | {{ project.name }}{% endblock %}
+
 {% block content %}
     {% include 'components/breadcrumbs.html.twig' %}
 

--- a/data/templates/woocommerce/namespace.html.twig
+++ b/data/templates/woocommerce/namespace.html.twig
@@ -1,5 +1,7 @@
 {% extends 'base.html.twig' %}
 
+{% block title %}{{ node.name == '\\' ? 'Global' : node.name }} Namespace | {{ project.name }}{% endblock %}
+
 {% block content %}
     {% include 'components/breadcrumbs.html.twig' %}
 

--- a/data/templates/woocommerce/package.html.twig
+++ b/data/templates/woocommerce/package.html.twig
@@ -1,5 +1,7 @@
 {% extends 'base.html.twig' %}
 
+{% block title %}{{ node.name }} | {{ project.name }}{% endblock %}
+
 {% block content %}
     {% include 'components/breadcrumbs.html.twig' %}
 


### PR DESCRIPTION
The title to every page (expect [Deprecated](https://woocommerce.github.io/code-reference/reports/deprecated.html), [Errors](https://woocommerce.github.io/code-reference/reports/errors.html), and [Markers](https://woocommerce.github.io/code-reference/reports/markers.html)) is "WooCommerce Code Reference".  This makes it annoying to use the site with multiple tabs.

### Screenshot Before:

![2022-03-16-before](https://user-images.githubusercontent.com/1833684/158646487-3359fefd-6f79-408d-9293-7188c8b593bd.PNG)
(click for larger image)


### Screenshot After:
![2022-03-16-after](https://user-images.githubusercontent.com/1833684/158646486-40cd1585-0bd3-4469-b52f-e730a3f058a3.PNG)
(click for larger image)


## Changes

I changed the code to prepend the name of the node to the document title.  The reason for prepending is so that you can see the name when you have a tab view similar to mine.  (See screenshots.)


<table>
<tr><th><code>(New part)</code> Old Title</th><th>URL</th></tr>
<tr>
	<td><code>Global Namespace | </code>WooCommerce Code Reference</td>
	<td><a href="https://woocommerce.github.io/code-reference/namespaces/default.html">.../namespaces/default.html</a></td>
</tr>
<tr>
	<td><code>WC_Queue_Interface | </code>WooCommerce Code Reference</td>
	<td><a href="https://woocommerce.github.io/code-reference/classes/WC-Queue-Interface.html">.../classes/WC-Queue-Interface.html</a></td>
</tr>
<tr>
	<td><code>Classes | </code>WooCommerce Code Reference</td>
	<td><a href="https://woocommerce.github.io/code-reference/packages/WooCommerce-Classes.html">.../packages/WooCommerce-Classes.html</a></td>
</tr>
<tr>
	<td><code>WC_Abstract_Order Class | </code>WooCommerce Code Reference</td>
	<td><a href="https://woocommerce.github.io/code-reference/classes/WC-Abstract-Order.html">.../classes/WC-Abstract-Order.html</a></td>
</tr>
<tr>
	<td><code>class-wc-queue-interface.php | </code>WooCommerce Code Reference</td>
	<td><a href="https://woocommerce.github.io/code-reference/files/woocommerce-includes-interfaces-class-wc-queue-interface.html">.../files/woocommerce-includes-interfaces<br>-class-wc-queue-interface.html</a></td>
</tr>
<tr>
	<td>WooCommerce Code Reference <i>(no change)</i></td>
	<td><a href="https://woocommerce.github.io/code-reference/index.html">.../index.html</a></td>
</tr>
</table>

