### PR TITLE
Fix regexp to strip phpcs comments

### DIFF
--- a/generate-hook-docs.php
+++ b/generate-hook-docs.php
@@ -179,7 +179,7 @@ class HookDocsGenerator
                                     $hook = str_replace('_CLASS_', strtoupper($current_class), $hook);
                                     $hook = str_replace('$this', strtoupper($current_class), $hook);
                                     $hook = str_replace(array( '.', '{', '}', '"', "'", ' ', ')', '(' ), '', $hook);
-                                    $hook = preg_replace('/\/\/phpcs:(.*)(\n)/', '', $hook);
+                                    $hook = preg_replace('/\/\/phpcs\:(.*)/', '', $hook);
                                     $loop = 0;
 
                                     // Keep adding to hook until we find a comma or colon.


### PR DESCRIPTION



### Changes proposed in this Pull Request:
Implements part of https://github.com/woocommerce/automatewoo/issues/1238

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR fixes the build for latest (9.1.2) WC release.

Currently, entries like https://github.com/woocommerce/woocommerce/blob/a126f00dd173d38052603cae477a18e8333650ba/plugins/woocommerce/templates/cart/cart.php#L60:L61

```php
echo apply_filters( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
	'woocommerce_cart_item_remove_link',
```
are not parsed correctly and result in `build/api/js/searchIndex.js` containing invalid content:

```
},{
        fqsen: "\\Automattic\\WooCommerce\\StoreApi\\Utilities",
        name: "Utilities",
        summary: "",
        url: "https://woocommerce.github.io/code-reference/namespaces/automattic-woocommerce-storeapi-utilities.html"
    },{
        fqsen: "\\Automattic\\WooCommerce\\Utilities",
        name: "Utilities",
        summary: "",
        url: "https://woocommerce.github.io/code-reference/namespaces/automattic-woocommerce-utilities.html"
    },{fqsen: "<strong>Filter hook: <\/strong>//phpcs:ignoreWordPressSecurityEscapeOutputOutputNotEscaped
									woocommerce_cart_item_remove_link",name: "//phpcs:ignoreWordPressSecurityEscapeOutputOutputNotEscaped
									woocommerce_cart_item_remove_link",summary: "Template Files Filter located in templates/cart/cart.php: 60",url: "https://woocommerce.github.io/code-reference/files/woocommerce-templates-cart-cart.html#source-view.60"},{fqsen: "<strong>Filter hook: <\/strong>//phpcs:ignoreWordPressSecurityEscapeOutputOutputNotEscaped
						woocommerce_cart_item_remove_link",name: "//phpcs:ignoreWordPressSecurityEscapeOutputOutputNotEscaped
						woocommerce_cart_item_remove_link",summary: "Templ
```

Which then breaks Search feature.

This PR fixes the regexp, escapes the colon, and removes EOL.


##### Before

![image](https://github.com/user-attachments/assets/c0b6d81a-3ef7-41a8-a8f7-5518e81ffc38)

##### After 
![image](https://github.com/user-attachments/assets/d3fe72f7-5323-4a13-8a73-60add4c10d94)


### How to test the changes in this Pull Request:


1. `/deploy.sh -v --build-only -s 9.1.2`
2. Check that `build/api/js/searchIndex.js` contains a valid JS object
3. Check that Search feature works well at `build/api/namespaces/woocommerce-admin.html`

<!-- End testing instructions -->

