### PR TITLE
Add prism-js to the classes template

### DIFF
--- a/data/templates/woocommerce/class.html.twig
+++ b/data/templates/woocommerce/class.html.twig
@@ -1,5 +1,14 @@
 {% extends 'base.html.twig' %}
 
+{% block javascripts %}
+    <script src="{{ path('js/prism.js') }}"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            window.dispatchEvent(new HashChangeEvent('hashchange'));
+        });
+    </script>
+{% endblock %}
+
 {% block content %}
     {% include 'components/breadcrumbs.html.twig' %}
 

--- a/data/templates/woocommerce/trait.html.twig
+++ b/data/templates/woocommerce/trait.html.twig
@@ -1,5 +1,14 @@
 {% extends 'base.html.twig' %}
 
+{% block javascripts %}
+    <script src="{{ path('js/prism.js') }}"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            window.dispatchEvent(new HashChangeEvent('hashchange'));
+        });
+    </script>
+{% endblock %}
+
 {% block content %}
     {% include 'components/breadcrumbs.html.twig' %}
 


### PR DESCRIPTION



### Changes proposed in this Pull Request:
Add prism-js to the classes template to enable code highlighting for code samples in the PHPDocs class.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->


1. Generate [code reference](https://github.com/woocommerce/code-reference) for the latest release: `./deploy.sh -v --build-only -s 9.1.4`
2. Edit some file locally to add code snippet inside doc block.:
`./woocommerce/src/Admin/API/Reports/DataStore.php`
```php

/**
 * Class description
 *
 * Example:
 * <pre><code class="language-php">class MyDataStore extends DataStore implements DataStoreInterface {
 *     /** Cache identifier. &ast;/
 *     protected $cache_key = 'my_example';
 * </code></pre>
 *
 */
class DataStore extends SqlQuery implements DataStoreInterface {
```
5. Generate again from local changes ``./deploy.sh -v --build-only -s 9.1.4 --no-download``
6. open `file:///path/to/code-reference/build/api/classes/Automattic-WooCommerce-Admin-API-Reports-DataStore.html`

##### Before
![image](https://github.com/user-attachments/assets/0b23128b-3e6d-4bdd-b778-bf91a516f014)



##### After 
![image](https://github.com/user-attachments/assets/66e68697-fd03-4ed2-a1df-02b947cf7763)

