### PR TITLE
[dev] Pin Github actions to full-commit SHA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Setup PHP with composer v2
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@0f7f1d08e3e32076e51cae65eb0b0c871405b16e # v2.34.1
       with:
         php-version: '7.4'
         tools: composer:v2
@@ -33,7 +33,7 @@ jobs:
         ./deploy.sh --build-only -s ${{ github.event.inputs.version }}
     - name: Deploy to GitHub Pages
       if: success()
-      uses: crazy-max/ghaction-github-pages@v2
+      uses: crazy-max/ghaction-github-pages@59173cb633d9a3514f5f4552a6a3e62c6710355c # v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
Closes [QAO-36](https://linear.app/a8c/issue/QAO-36/pin-github-actions-to-full-commit-shas-for-immutability)
Contributes to [QAO-23](https://linear.app/a8c/issue/QAO-23)

Pins Github actions to full commit SHAs as immutable references.
Skipped all official GitHub actions.  
No version updates - used the latest commit in the tag that was already used.