### PR TITLE
Various deploy job fixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'WooCommerce Version'
-        required: true
+        description: 'WooCommerce version (defaults to latest release in repository)'
+        required: false
+        default: ''
 jobs:
   build-and-deploy:
     name: Build and deploy
@@ -28,9 +29,22 @@ jobs:
         restore-keys: ${{ runner.os }}-composer-
     - name: Install dependencies
       run: composer install --prefer-dist
+    - name: Fetch latest release version if not provided
+      id: get-latest-version
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        INPUT_VERSION: ${{ github.event.inputs.version }}
+      run: |
+        if [ -z "$INPUT_VERSION" ]; then
+          VERSION=$(gh release view --repo "$GITHUB_REPOSITORY_OWNER/woocommerce" --json tagName -q .tagName)
+        else
+          VERSION="$INPUT_VERSION"
+        fi
+
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
     - name: Build
       run: |
-        ./deploy.sh --build-only -s ${{ github.event.inputs.version }}
+        ./deploy.sh --build-only -s ${{ steps.get-latest-version.outputs.version }} -r "$GITHUB_REPOSITORY_OWNER/woocommerce"
     - name: Deploy to GitHub Pages
       if: success()
       uses: crazy-max/ghaction-github-pages@59173cb633d9a3514f5f4552a6a3e62c6710355c # v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,7 @@
 name: GitHub Pages deploy
 on:
+  schedule:
+    - cron: '0 23 * * *'
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Setup PHP with composer v2
       uses: shivammathur/setup-php@0f7f1d08e3e32076e51cae65eb0b0c871405b16e # v2.34.1
       with:
@@ -21,7 +21,7 @@ jobs:
       id: composer-cache
       run: echo "::set-output name=dir::$(composer config cache-files-dir)"
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
         tools: composer:v2
     - name: Get composer cache directory
       id: composer-cache
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
     - name: Cache dependencies
       uses: actions/cache@v4
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup PHP with composer v2
       uses: shivammathur/setup-php@0f7f1d08e3e32076e51cae65eb0b0c871405b16e # v2.34.1
       with:
-        php-version: '7.4'
+        php-version: '8.1'
         tools: composer:v2
     - name: Get composer cache directory
       id: composer-cache

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,9 +9,48 @@ on:
         required: false
         default: ''
 jobs:
+  verify:
+    name: Verify if a rebuild is needed
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-latest-version.outputs.version }}
+      rebuild: ${{ steps.check-if-built.outputs.rebuild }}
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Fetch latest release version if not provided
+      id: get-latest-version
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        INPUT_VERSION: ${{ github.event.inputs.version }}
+      run: |
+        if [ -z "$INPUT_VERSION" ]; then
+          VERSION=$(gh release view --repo "$GITHUB_REPOSITORY_OWNER/woocommerce" --json tagName -q .tagName)
+        else
+          VERSION="$INPUT_VERSION"
+        fi
+
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+    - name: Check if build is necessary
+      id: check-if-built
+      env:
+        VERSION: ${{ steps.get-latest-version.outputs.version }}
+      run: |
+        last_built_version=$(git log -1 --pretty=%B 'origin/gh-pages' | grep -oP '\d+\.\d+\.\d+')
+
+        if [ "$last_built_version" = "$VERSION" ]; then
+            echo "rebuild=false" >> $GITHUB_OUTPUT
+        else
+            echo "rebuild=true" >> $GITHUB_OUTPUT
+        fi
+
   build-and-deploy:
     name: Build and deploy
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
+    needs: verify
+    if: ${{ needs.verify.outputs.rebuild == 'true' }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -31,22 +70,9 @@ jobs:
         restore-keys: ${{ runner.os }}-composer-
     - name: Install dependencies
       run: composer install --prefer-dist
-    - name: Fetch latest release version if not provided
-      id: get-latest-version
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        INPUT_VERSION: ${{ github.event.inputs.version }}
-      run: |
-        if [ -z "$INPUT_VERSION" ]; then
-          VERSION=$(gh release view --repo "$GITHUB_REPOSITORY_OWNER/woocommerce" --json tagName -q .tagName)
-        else
-          VERSION="$INPUT_VERSION"
-        fi
-
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
     - name: Build
       run: |
-        ./deploy.sh --build-only -s ${{ steps.get-latest-version.outputs.version }} -r "$GITHUB_REPOSITORY_OWNER/woocommerce"
+        ./deploy.sh --build-only -s ${{ needs.verify.outputs.version }} -r "$GITHUB_REPOSITORY_OWNER/woocommerce"
     - name: Deploy to GitHub Pages
       if: success()
       uses: crazy-max/ghaction-github-pages@59173cb633d9a3514f5f4552a6a3e62c6710355c # v2
@@ -55,4 +81,4 @@ jobs:
       with:
         target_branch: gh-pages
         build_dir: build/api
-        commit_message: "${{ format('Build: {0}', steps.get-latest-version.outputs.version) }}"
+        commit_message: "${{ format('Build: {0}', needs.verify.outputs.version) }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,3 +55,4 @@ jobs:
       with:
         target_branch: gh-pages
         build_dir: build/api
+        commit_message: "${{ format('Build: {0}', steps.get-latest-version.outputs.version) }}"


### PR DESCRIPTION
This PR:

- Updates the cache and checkout action versions used in this workflow, with `v2` no longer being supported.
- Updates the PHP version in use for the Composer step, with 7.4 no longer being supported by the required packages.
- Makes the version input optional, defaulting to building the docs for the _latest_ WC version from the `woocommerce` repository.
- Adds some logic to prevent re-building the code reference for a version that was already built.
- Turns the workflow into a cron job that runs at 23:00 UTC every day.

Closes https://github.com/woocommerce/woocommerce/issues/57960.


### Testing instructions

1. Fork the `woocommerce/woocommerce` repository.
1. In this fork, create two **draft** releases:
   1. One with tag name `9.9.4`, marked as the latest and attaching [the ZIP from WordPress.org](https://downloads.wordpress.org/plugin/woocommerce.9.9.4.zip) as `woocommerce.zip`.
   1. One with tag name `9.9.5`, marked as the latest and attaching [the ZIP from WordPress.org](https://downloads.wordpress.org/plugin/woocommerce.9.9.5.zip) as `woocommerce.zip`.
1. Fork this repository as well (`woocommerce/code-reference`). Make sure that your fork has all branches (not just `trunk`) and that this branch (`deploy-job-fixes`) is merged into `trunk`.
1. In your fork of `code-reference`:
   1. Ensure that actions are enabled in the **Actions** tab.
   1. In **Settings > Pages**, set **Source** to deploy from the `gh-pages` branch.
   1. Go to `https://<your username>.github.io/code-reference/classes/WooCommerce.html#property_version` and confirm that you see that `$version` is said to be set to `9.8.5`.

      Note: You might need to wait a few mins for GH pages to be deployed.
1. Publish the `9.9.4` release in your fork of the core repo.
1. Run workflow _GitHub Pages deploy_ in your fork of the `code-reference` repo and wait until it completes.
1. After a few minutes you should be able to refresh `https://<your username>.github.io/code-reference/classes/WooCommerce.html#property_version` and see that `9.9.4` is now the number associated to `$version`, meaning the docs were re-generated from the new version.
1. Run workflow _GitHub Pages deploy_ again and confirm that the second job (_Build and deploy_) is now skipped. This is because the docs for the latest version were already built.
1. Publish the `9.9.5` release in your fork of the core repo.
1. Run workflow _GitHub Pages deploy_ in your fork of the `code-reference` repo and wait until it completes.
1. After a few minutes you should be able to refresh `https://<your username>.github.io/code-reference/classes/WooCommerce.html#property_version` and confirm that the docs now correspond to version `9.9.5`.