### PR TITLE
Add Algolia site verification meta tag

### DIFF
--- a/data/templates/woocommerce/layout.html.twig
+++ b/data/templates/woocommerce/layout.html.twig
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>{% block title %}{{ project.name }}{% endblock %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="algolia-site-verification"  content="16BACF3DF9DCEE45" />
     <link rel="icon" href="{{ path('images/favicon-32x32.png') }}" sizes="32x32" />
     <link rel="icon" href="{{ path('images/favicon-192x192.png') }}" sizes="192x192" />
     <link rel="apple-touch-icon" href="{{ path('images/favicon-180x180.png') }}" />


### PR DESCRIPTION
On the [developer documentation](https://developer.woocommerce.com/docs) site, we get a number of searches for Woo function and class names.

We'd like to experiment with indexing the codex itself and seeing if adding those links to the search results will result in a higher hit rate for searches.