### PR TITLE
Fix wrong capitalization of links in hooks reference

### DIFF
--- a/generate-hook-docs.php
+++ b/generate-hook-docs.php
@@ -63,6 +63,7 @@ class HookDocsGenerator
     {
         $url = str_replace('.php', '.html#source-view.' . $file['line'], $file['path']);
         $url = str_replace(['_', '/'], '-', $url);
+        $url = strtolower($url);
 
         return '../files/' . $url;
     }


### PR DESCRIPTION
Files output by phpDocumentor are all lowercase, yet when generating the hooks reference we might end up with links that honor the capitalization of the filename (e.g. https://woocommerce.github.io/code-reference/files/woocommerce-src-Blocks-BlockTypes-ProductSaleBadge.html) which result in a 404 under Linux, given the filesystem is case sensitive.

This PR ensures that all links in the hooks reference are lower case.

### Testing instructions

1. Set up the dev environment by running `composer install`.
2. Run `./deploy.sh -s 10.4.3 -v --build-only`.
3. Open `build/api/index.html` in your browser of choice.
4. Navigate to **Hooks Reference** (top right).
5. Search for "ProductSaleBadge" and inspect the link to confirm the `href` is all lower case. Click the link to confirm it works.

Related: p1768901618368859-slack-C02NVV8LQLW