### PR TITLE
Replace crazy-max/ghaction-github-pages with official GitHub Pages actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,16 @@ on:
         description: 'WooCommerce version (defaults to latest release in repository)'
         required: false
         default: ''
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   verify:
     name: Verify if a rebuild is needed
@@ -38,9 +48,7 @@ jobs:
       env:
         VERSION: ${{ steps.get-latest-version.outputs.version }}
       run: |
-        last_built_version=$(git log -1 --pretty=%B 'origin/gh-pages' | grep -oP '\d+\.\d+\.\d+')
-
-        if [ "$last_built_version" = "$VERSION" ]; then
+        if git tag -l "pages-deploy/${VERSION}" | grep -q .; then
             echo "rebuild=false" >> $GITHUB_OUTPUT
         else
             echo "rebuild=true" >> $GITHUB_OUTPUT
@@ -51,6 +59,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: verify
     if: ${{ needs.verify.outputs.rebuild == 'true' }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -73,12 +84,16 @@ jobs:
     - name: Build
       run: |
         ./deploy.sh --build-only -s ${{ needs.verify.outputs.version }} -r "$GITHUB_REPOSITORY_OWNER/woocommerce"
-    - name: Deploy to GitHub Pages
-      if: success()
-      uses: crazy-max/ghaction-github-pages@59173cb633d9a3514f5f4552a6a3e62c6710355c # v2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Setup Pages
+      uses: actions/configure-pages@v5
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
       with:
-        target_branch: gh-pages
-        build_dir: build/api
-        commit_message: "${{ format('Build: {0}', needs.verify.outputs.version) }}"
+        path: build/api
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4
+    - name: Tag deployed version
+      run: |
+        git tag "pages-deploy/${{ needs.verify.outputs.version }}"
+        git push origin "pages-deploy/${{ needs.verify.outputs.version }}"


### PR DESCRIPTION
## Summary
- Replace `crazy-max/ghaction-github-pages` with the official `actions/upload-pages-artifact@v3` and `actions/deploy-pages@v4`
- Switch version tracking from reading `gh-pages` branch commit messages to using `pages-deploy/<version>` git tags
- Add proper `permissions`, `concurrency`, and `environment` configuration consistent with the [already-migrated woocommerce-rest-api-docs repo](https://github.com/woocommerce/woocommerce-rest-api-docs/blob/trunk/.github/workflows/deploy.yml)

## Notes
- The repository's GitHub Pages source setting must be changed from "Deploy from a branch" to "GitHub Actions" for this to work
- The first run after merging will rebuild regardless since no `pages-deploy/*` tags exist yet

## Test plan
- [ ] Update the repo's Pages source setting to "GitHub Actions"
- [ ] Trigger a manual workflow run and verify the site deploys correctly
- [ ] Verify a `pages-deploy/<version>` tag is created after successful deployment
- [ ] Trigger a second run and verify it skips the build (tag already exists)

Closes QAO-31 (code-reference checkbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)