### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       rebuild: ${{ steps.check-if-built.outputs.rebuild }}
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         fetch-depth: 0
     - name: Fetch latest release version if not provided
@@ -64,7 +64,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     - name: Setup PHP with composer v2
       uses: shivammathur/setup-php@0f7f1d08e3e32076e51cae65eb0b0c871405b16e # v2.34.1
       with:
@@ -74,7 +74,7 @@ jobs:
       id: composer-cache
       run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -85,14 +85,14 @@ jobs:
       run: |
         ./deploy.sh --build-only -s ${{ needs.verify.outputs.version }} -r "$GITHUB_REPOSITORY_OWNER/woocommerce"
     - name: Setup Pages
-      uses: actions/configure-pages@v5
+      uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
       with:
         path: build/api
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
     - name: Tag deployed version
       run: |
         git tag "pages-deploy/${{ needs.verify.outputs.version }}"


### PR DESCRIPTION
## Summary

WooCommerce intends to enforce an organization-wide requirement that GitHub Actions references use full-length commit SHAs. This change pins 6 external Action references across 1 configuration file while retaining each original version or branch in a trailing comment.

Immutable Action pins reduce supply-chain compromise risk: a moved or compromised mutable tag or branch can no longer silently change the code executed by these workflows.

Local actions and reusable workflows are unchanged.

## Verification

- Re-resolved every original Action tag or branch through the GitHub API and confirmed each full SHA.
- Confirmed the repository has zero remaining unpinned external Action references in workflow and composite-action configuration.
- Parsed every changed YAML file successfully.
- Ran `git diff --check`.
- Confirmed the diff changes only `uses:` references.

No application tests were run because this is workflow-only configuration. No changelog entry is needed for the same reason.
