### PR TITLE
Pin nested GitHub Action dependencies to full SHAs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,7 +87,7 @@ jobs:
     - name: Setup Pages
       uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
       with:
         path: build/api
     - name: Deploy to GitHub Pages


### PR DESCRIPTION
### Changes proposed in this Pull Request

Tracking: WOODOCS-3766

- Updates the affected parent actions or reusable workflows to immutable commits whose own remote action dependencies are pinned to full-length SHAs.
- Keeps human-readable version comments beside the SHAs.

This is part of the WooCommerce organization audit for transitive GitHub Action pinning. The shared Grow actions are sourced from the successful test build for woocommerce/grow#265.

### Detailed test instructions

1. Inspect the changed `uses:` references and confirm every remote action ref is a 40-character commit SHA.
2. Confirm the adjacent comments identify the intended version or upstream pinning PR.
3. Let the affected workflows run through this PR's hosted checks.

Validation already completed:

- Parsed every GitHub workflow and composite action in this repository as YAML.
- Ran `git diff --check`.
- Verified the replacement parent commits resolve through their canonical GitHub repositories.
- Verified their nested remote action dependencies are pinned to full-length SHAs.

### Documentation

- [x] No documentation changes are required.

### Changelog entry

> Dev - Pin GitHub Actions and their nested dependencies to immutable commit SHAs.

**left by Biff (AI agent) on behalf of Darren*
