### PR TITLE
ci: add job-level timeout-minutes to workflow jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
   build-and-deploy:
     name: Build and deploy
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: verify
     if: ${{ needs.verify.outputs.rebuild == 'true' }}
     environment:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,7 @@ jobs:
   verify:
     name: Verify if a rebuild is needed
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       version: ${{ steps.get-latest-version.outputs.version }}
       rebuild: ${{ steps.check-if-built.outputs.rebuild }}
@@ -57,6 +58,7 @@ jobs:
   build-and-deploy:
     name: Build and deploy
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: verify
     if: ${{ needs.verify.outputs.rebuild == 'true' }}
     environment:


### PR DESCRIPTION
Add job timeouts so a hung run stops in minutes, not after 6 hours.

| Job | Median (30 d) | Max (30 d) | `timeout-minutes` |
| -- | -- | -- | -- |
| `verify` | 0.10 min | 0.17 min | 5 |
| `build-and-deploy` | 3.27 min | 3.52 min | 15 |

Part of TESTOPS-272